### PR TITLE
SAOD-664 - MA - Adds Bruno test for multiple constraint violations

### DIFF
--- a/bruno/get obligation (200).yml
+++ b/bruno/get obligation (200).yml
@@ -1,7 +1,7 @@
 info:
   name: get obligation (200)
   type: http
-  seq: 12
+  seq: 13
 
 http:
   method: GET

--- a/bruno/get obligation (404) Invalid Id.yml
+++ b/bruno/get obligation (404) Invalid Id.yml
@@ -1,7 +1,7 @@
 info:
   name: get obligation (404) Invalid Id
   type: http
-  seq: 13
+  seq: 14
 
 http:
   method: GET

--- a/bruno/post certificate (400) multiple constraint violations.yml
+++ b/bruno/post certificate (400) multiple constraint violations.yml
@@ -1,0 +1,60 @@
+info:
+  name: post certificate (400) multiple constraint violations
+  type: http
+  seq: 12
+
+http:
+  method: POST
+  url: "{{baseUrl}}/certificate/123"
+  headers:
+    - name: Authorization
+      value: Basic {{base64Password}}
+  body:
+    type: json
+    data: |-
+      {
+        "companies": [
+          {
+            "companyName": "" ,
+            "uniqueTaxReference": "1234567890",
+            "companyReferenceNumber": "AB123456",
+            "companyType": "LTD",
+            "financialYearEndDate": "ERROR",
+            "qualifiedRegimes": [
+              "CORPORATION",
+              "CORPORATION",
+              "VALUE_ADDED"
+            ],
+            "qualificationStatement": "All relevant corporation and VAT obligations have been delayed due to grievance.",
+            "seniorAccountingOfficers": [
+            ]
+          },
+          {
+            "companyName": "Example PLC",
+            "uniqueTaxReference": "0987654321",
+            "companyReferenceNumber": "CD654321",
+            "companyType": "SUMMIT",
+            "financialYearEndDate": "2024-06-30",
+            "isDormant": true,
+            "isInAdministration": false,
+            "qualifiedRegimes": [
+              "PAY_AS_YOU_EARN",
+              "PETROLEUM_REVENUE"
+            ],
+            "seniorAccountingOfficers": [
+              {
+                "name": "Another Officer",
+                "startDate": "2024-05-01",
+                "endDate": "2025-04-30"
+              }
+            ]
+          }
+        ],
+        "additionalInformation": "non-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty string"
+      }
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/bruno/put subscription (200).yml
+++ b/bruno/put subscription (200).yml
@@ -1,7 +1,7 @@
 info:
   name: put subscription (200)
   type: http
-  seq: 14
+  seq: 15
 
 http:
   method: PUT

--- a/bruno/put subscription (400) Invalid body.yml
+++ b/bruno/put subscription (400) Invalid body.yml
@@ -1,7 +1,7 @@
 info:
   name: put subscription (400) Invalid body
   type: http
-  seq: 15
+  seq: 16
 
 http:
   method: PUT


### PR DESCRIPTION
Adds a Bruno test to test constraint violations when making a call to **POST  '.../certificate/123'**. 

The response shows the following:

```
[
  {
    "path": "additionalInformation",
    "reason": "LENGTH_OUT_OF_BOUNDS"
  },
  {
    "path": "companies[0].companyName",
    "reason": "CANNOT_BE_EMPTY"
  },
  {
    "path": "companies[0].financialYearEndDate",
    "reason": "INVALID_FORMAT"
  },
  {
    "path": "companies[0].seniorAccountingOfficers",
    "reason": "ARRAY_MIN_ITEMS_NOT_MET"
  },
  {
    "path": "companies[1].companyType",
    "reason": "INVALID_ENUM_VALUE"
  },
  {
    "path": "declaration",
    "reason": "MISSING_REQUIRED_FIELD"
  }
]
```