### PR TITLE
SAOD-662 - MA - Adds Bruno test for multiple constraint violations

### DIFF
--- a/bruno/get contact details (200).yml
+++ b/bruno/get contact details (200).yml
@@ -1,7 +1,7 @@
 info:
   name: get contact details (200)
   type: http
-  seq: 4
+  seq: 5
 
 http:
   method: GET

--- a/bruno/get contact details (404) Invalid Id.yml
+++ b/bruno/get contact details (404) Invalid Id.yml
@@ -1,7 +1,7 @@
 info:
   name: get contact details (404) Invalid Id
   type: http
-  seq: 5
+  seq: 6
 
 http:
   method: GET

--- a/bruno/get obligation (200).yml
+++ b/bruno/get obligation (200).yml
@@ -1,7 +1,7 @@
 info:
   name: get obligation (200)
   type: http
-  seq: 13
+  seq: 14
 
 http:
   method: GET

--- a/bruno/get obligation (404) Invalid Id.yml
+++ b/bruno/get obligation (404) Invalid Id.yml
@@ -1,7 +1,7 @@
 info:
   name: get obligation (404) Invalid Id
   type: http
-  seq: 14
+  seq: 15
 
 http:
   method: GET

--- a/bruno/post certificate (200).yml
+++ b/bruno/post certificate (200).yml
@@ -1,7 +1,7 @@
 info:
   name: post certificate (200)
   type: http
-  seq: 9
+  seq: 10
 
 http:
   method: POST

--- a/bruno/post certificate (400) Invalid body.yml
+++ b/bruno/post certificate (400) Invalid body.yml
@@ -1,7 +1,7 @@
 info:
   name: post certificate (400) Invalid body
   type: http
-  seq: 11
+  seq: 12
 
 http:
   method: POST

--- a/bruno/post certificate (400) multiple constraint violations.yml
+++ b/bruno/post certificate (400) multiple constraint violations.yml
@@ -1,7 +1,7 @@
 info:
   name: post certificate (400) multiple constraint violations
   type: http
-  seq: 12
+  seq: 13
 
 http:
   method: POST

--- a/bruno/post certificate (404) Invalid Id.yml
+++ b/bruno/post certificate (404) Invalid Id.yml
@@ -1,7 +1,7 @@
 info:
   name: post certificate (404) Invalid Id
   type: http
-  seq: 10
+  seq: 11
 
 http:
   method: POST

--- a/bruno/post notification (400) multiple constraint violations.yml
+++ b/bruno/post notification (400) multiple constraint violations.yml
@@ -1,0 +1,65 @@
+info:
+  name: post notification (400) multiple constraint violations
+  type: http
+  seq: 4
+
+http:
+  method: POST
+  url: "{{baseUrl}}/notification/123"
+  headers:
+    - name: Authorization
+      value: Basic {{base64Password}}
+  body:
+    type: json
+    data: |-
+      {
+        "companies": [
+          {
+            "companyName": "",
+            "uniqueTaxReference": "1234567890",
+            "companyReferenceNumber": "AB123456",
+            "companyType": "LTD",
+            "financialYearEndDate": "2024-12-31",
+            "seniorAccountingOfficers": [
+              {
+                "name": "Firstname Lastname",
+                "email": "Firstname.Lastname@example.com",
+                "startDate": "2024-04-01",
+                "endDate": "2025-03-31"
+              },
+              {
+                "name": "Secondpersonname Theirlastname",
+                "email": "nonemptyemail@companyname.com",
+                "startDate": "2024-12-01",
+                "endDate": "2025-12-31"
+              }
+            ]
+          },
+          {
+            "companyName": "Example PLC",
+            "uniqueTaxReference": "0987654321",
+            "companyReferenceNumber": "CD654321",
+            "companyType": "PLCW",
+            "financialYearEndDate": "2024-06-30",
+            "seniorAccountingOfficers": [
+              {
+                "name": "Firstname Lastname",
+                "address": "SOME RANDOM THING",
+                "email": "Firstname.Lastname      example.com",
+                "startDate": "1 Jan 2020",
+                "endDate": "---"
+              }, 
+              {
+                
+              }
+            ]
+          }
+        ],
+        "additionalInformation": "non-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty stringnon-empty string"
+      }
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/bruno/put contact details (204).yml
+++ b/bruno/put contact details (204).yml
@@ -1,7 +1,7 @@
 info:
   name: put contact details (204)
   type: http
-  seq: 6
+  seq: 7
 
 http:
   method: PUT

--- a/bruno/put contact details (400) Invalid body.yml
+++ b/bruno/put contact details (400) Invalid body.yml
@@ -1,7 +1,7 @@
 info:
   name: put contact details (400) Invalid body
   type: http
-  seq: 8
+  seq: 9
 
 http:
   method: PUT

--- a/bruno/put contact details (404) Invalid Id.yml
+++ b/bruno/put contact details (404) Invalid Id.yml
@@ -1,7 +1,7 @@
 info:
   name: put contact details (404) Invalid Id
   type: http
-  seq: 7
+  seq: 8
 
 http:
   method: PUT

--- a/bruno/put subscription (200).yml
+++ b/bruno/put subscription (200).yml
@@ -1,7 +1,7 @@
 info:
   name: put subscription (200)
   type: http
-  seq: 15
+  seq: 16
 
 http:
   method: PUT

--- a/bruno/put subscription (400) Invalid body.yml
+++ b/bruno/put subscription (400) Invalid body.yml
@@ -1,7 +1,7 @@
 info:
   name: put subscription (400) Invalid body
   type: http
-  seq: 16
+  seq: 17
 
 http:
   method: PUT


### PR DESCRIPTION
Adds a Bruno test to test constraint violations when making a call to POST '.../notification/123'.

The response shows the following:

```
[
  {
    "path": "additionalInformation",
    "reason": "LENGTH_OUT_OF_BOUNDS"
  },
  {
    "path": "companies[0].companyName",
    "reason": "CANNOT_BE_EMPTY"
  },
  {
    "path": "companies[1].companyType",
    "reason": "INVALID_ENUM_VALUE"
  },
  {
    "path": "companies[1].seniorAccountingOfficers[0].email",
    "reason": "INVALID_FORMAT"
  },
  {
    "path": "companies[1].seniorAccountingOfficers[0].endDate",
    "reason": "INVALID_FORMAT"
  },
  {
    "path": "companies[1].seniorAccountingOfficers[0].startDate",
    "reason": "INVALID_FORMAT"
  },
  {
    "path": "companies[1].seniorAccountingOfficers[1].endDate",
    "reason": "MISSING_REQUIRED_FIELD"
  },
  {
    "path": "companies[1].seniorAccountingOfficers[1].name",
    "reason": "MISSING_REQUIRED_FIELD"
  },
  {
    "path": "companies[1].seniorAccountingOfficers[1].startDate",
    "reason": "MISSING_REQUIRED_FIELD"
  }
]
```