### PR TITLE
SAOD-651 - MA - Adds Bruno test for multiple constraint violations

### DIFF
--- a/bruno/put subscription (400) multiple constraint violations.yml
+++ b/bruno/put subscription (400) multiple constraint violations.yml
@@ -1,0 +1,37 @@
+info:
+  name: put subscription (400) multiple constraint violations
+  type: http
+  seq: 18
+
+http:
+  method: PUT
+  url: "{{baseUrl}}/subscriptions"
+  headers:
+    - name: Authorization
+      value: Basic {{base64Password}}
+  body:
+    type: json
+    data: |-
+      {
+        //"safeId": "XE000123456789",
+        "company": {
+          "companyName": "Acme Manufacturing Ltd",
+          "uniqueTaxReference": "12345678901212121212121212",
+          "CompanyRegistrationNumber": "OC123456"
+        },
+        "contacts": [
+          {
+            "name": "",
+            "email": "jane.doe.example.com"
+          },
+          {
+          }
+        ]
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5


### PR DESCRIPTION
Adds a Bruno test to test constraint violations when making a call to PUT '.../subscriptions'.

The response shows the following:

```
[
  {
    "path": "company.CompanyRegistrationNumber",
    "reason": "INVALID_DATA_TYPE"
  },
  {
    "path": "company.companyRegistrationNumber",
    "reason": "MISSING_REQUIRED_FIELD"
  },
  {
    "path": "company.uniqueTaxReference",
    "reason": "INVALID_FORMAT"
  },
  {
    "path": "contacts[0].email",
    "reason": "INVALID_FORMAT"
  },
  {
    "path": "contacts[0].name",
    "reason": "CANNOT_BE_EMPTY"
  },
  {
    "path": "contacts[1].email",
    "reason": "MISSING_REQUIRED_FIELD"
  },
  {
    "path": "contacts[1].name",
    "reason": "MISSING_REQUIRED_FIELD"
  },
  {
    "path": "safeId",
    "reason": "MISSING_REQUIRED_FIELD"
  }
]
```