### PR TITLE
SAOD-660 - MA - Adds Bruno test for multiple constraint violations

### DIFF
--- a/bruno/get obligation (200).yml
+++ b/bruno/get obligation (200).yml
@@ -1,7 +1,7 @@
 info:
   name: get obligation (200)
   type: http
-  seq: 14
+  seq: 15
 
 http:
   method: GET

--- a/bruno/get obligation (404) Invalid Id.yml
+++ b/bruno/get obligation (404) Invalid Id.yml
@@ -1,7 +1,7 @@
 info:
   name: get obligation (404) Invalid Id
   type: http
-  seq: 15
+  seq: 16
 
 http:
   method: GET

--- a/bruno/post certificate (200).yml
+++ b/bruno/post certificate (200).yml
@@ -1,7 +1,7 @@
 info:
   name: post certificate (200)
   type: http
-  seq: 10
+  seq: 11
 
 http:
   method: POST

--- a/bruno/post certificate (400) Invalid body.yml
+++ b/bruno/post certificate (400) Invalid body.yml
@@ -1,7 +1,7 @@
 info:
   name: post certificate (400) Invalid body
   type: http
-  seq: 12
+  seq: 13
 
 http:
   method: POST

--- a/bruno/post certificate (400) multiple constraint violations.yml
+++ b/bruno/post certificate (400) multiple constraint violations.yml
@@ -1,7 +1,7 @@
 info:
   name: post certificate (400) multiple constraint violations
   type: http
-  seq: 13
+  seq: 14
 
 http:
   method: POST

--- a/bruno/post certificate (404) Invalid Id.yml
+++ b/bruno/post certificate (404) Invalid Id.yml
@@ -1,7 +1,7 @@
 info:
   name: post certificate (404) Invalid Id
   type: http
-  seq: 11
+  seq: 12
 
 http:
   method: POST

--- a/bruno/put contact details (400) multiple constraint violations.yml
+++ b/bruno/put contact details (400) multiple constraint violations.yml
@@ -1,0 +1,34 @@
+info:
+  name: put contact details (400) multiple constraint violations
+  type: http
+  seq: 10
+
+http:
+  method: PUT
+  url: "{{baseUrl}}/contact-details/123"
+  headers:
+    - name: Authorization
+      value: Basic {{base64Password}}
+  body:
+    type: json
+    data: |-
+      [
+        {
+          "name": "Jane Doe",
+          "email": "jane.doe@acme.com",
+          "dob": "12Jan1980"
+        },
+        {
+          "Name": "John Smith",
+          "email": "john.smith=acme.com"
+        },
+        {
+        }
+      ]
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/bruno/put subscription (200).yml
+++ b/bruno/put subscription (200).yml
@@ -1,7 +1,7 @@
 info:
   name: put subscription (200)
   type: http
-  seq: 16
+  seq: 17
 
 http:
   method: PUT

--- a/bruno/put subscription (400) Invalid body.yml
+++ b/bruno/put subscription (400) Invalid body.yml
@@ -1,7 +1,7 @@
 info:
   name: put subscription (400) Invalid body
   type: http
-  seq: 17
+  seq: 18
 
 http:
   method: PUT

--- a/bruno/put subscription (400) multiple constraint violations.yml
+++ b/bruno/put subscription (400) multiple constraint violations.yml
@@ -1,7 +1,7 @@
 info:
   name: put subscription (400) multiple constraint violations
   type: http
-  seq: 18
+  seq: 19
 
 http:
   method: PUT


### PR DESCRIPTION
Adds a Bruno test to test constraint violations when making a call to PUT '.../contact-details/123'.

The response shows the following:


```
[
  {
    "path": "[0].dob",
    "reason": "INVALID_DATA_TYPE"
  },
  {
    "path": "[1].Name",
    "reason": "INVALID_DATA_TYPE"
  },
  {
    "path": "[1].email",
    "reason": "INVALID_FORMAT"
  },
  {
    "path": "[1].name",
    "reason": "MISSING_REQUIRED_FIELD"
  },
  {
    "path": "[2].email",
    "reason": "MISSING_REQUIRED_FIELD"
  },
  {
    "path": "[2].name",
    "reason": "MISSING_REQUIRED_FIELD"
  },
  {
    "path": "body",
    "reason": "LENGTH_OUT_OF_BOUNDS"
  }
]
```